### PR TITLE
Implement pod specific slack cc'ing for integration results

### DIFF
--- a/envrc.template
+++ b/envrc.template
@@ -1,6 +1,9 @@
 export SLACK_HOOK_URL=""
 # It's important that the following env var is formatted exactly as follows!
-export SLACK_USER_IDS="<@U1>, <@U2>"
+export MAIN_SLACK_USER_IDS="<@U1>, <@U2>"
+export EATERY_SLACK_USER_IDS="<@U1>, <@U2>"
+export TRANSIT_SLACK_USER_IDS="<@U1>, <@U2>"
+export UPLIFT_SLACK_USER_IDS="<@U1>, <@U2>"
 
 # backend_urls
 export EATERY_BACKEND_URL=""

--- a/envrc.template
+++ b/envrc.template
@@ -1,6 +1,6 @@
 export SLACK_HOOK_URL=""
 # It's important that the following env var is formatted exactly as follows!
-export MAIN_SLACK_USER_IDS="<@U1>, <@U2>"
+export ADMIN_SLACK_USER_IDS="<@U1>, <@U2>"
 export EATERY_SLACK_USER_IDS="<@U1>, <@U2>"
 export TRANSIT_SLACK_USER_IDS="<@U1>, <@U2>"
 export UPLIFT_SLACK_USER_IDS="<@U1>, <@U2>"

--- a/src/coursegrab/tests.py
+++ b/src/coursegrab/tests.py
@@ -1,10 +1,8 @@
 from os import environ
 
-from models import Request, Test, TestGroup, Pod
+from models import Pod, Request, Test, TestGroup
 
-BASE_URL = (
-    "https://coursegrab.cornellappdev.com"
-)  # We don't need to mask this since it's public!
+BASE_URL = "https://coursegrab.cornellappdev.com"  # We don't need to mask this since it's public!
 
 tests = [Test(name="Root URL", request=Request(method="GET", url=BASE_URL))]
 

--- a/src/coursegrab/tests.py
+++ b/src/coursegrab/tests.py
@@ -1,9 +1,7 @@
-from os import environ
-
-from models import Pod, Request, Test, TestGroup
+from models import Application, Request, Test, TestGroup
 
 BASE_URL = "https://coursegrab.cornellappdev.com"  # We don't need to mask this since it's public!
 
 tests = [Test(name="Root URL", request=Request(method="GET", url=BASE_URL))]
 
-coursegrab_tests = TestGroup(name="CourseGrab", pod=Pod.COURSEGRAB, tests=tests)
+coursegrab_tests = TestGroup(application=Application.COURSEGRAB, name="CourseGrab", tests=tests)

--- a/src/coursegrab/tests.py
+++ b/src/coursegrab/tests.py
@@ -1,6 +1,6 @@
 from os import environ
 
-from models import Request, Test, TestGroup
+from models import Request, Test, TestGroup, Pod
 
 BASE_URL = (
     "https://coursegrab.cornellappdev.com"
@@ -8,4 +8,4 @@ BASE_URL = (
 
 tests = [Test(name="Root URL", request=Request(method="GET", url=BASE_URL))]
 
-coursegrab_tests = TestGroup(name="CourseGrab", tests=tests)
+coursegrab_tests = TestGroup(name="CourseGrab", tests=tests, pod=Pod.COURSEGRAB)

--- a/src/coursegrab/tests.py
+++ b/src/coursegrab/tests.py
@@ -6,4 +6,4 @@ BASE_URL = "https://coursegrab.cornellappdev.com"  # We don't need to mask this 
 
 tests = [Test(name="Root URL", request=Request(method="GET", url=BASE_URL))]
 
-coursegrab_tests = TestGroup(name="CourseGrab", tests=tests, pod=Pod.COURSEGRAB)
+coursegrab_tests = TestGroup(name="CourseGrab", pod=Pod.COURSEGRAB, tests=tests)

--- a/src/eatery/tests.py
+++ b/src/eatery/tests.py
@@ -7,4 +7,4 @@ URL_PARAMS = "?query=query%7Beateries%20%7Bname%7D%7D"
 
 tests = [Test(name="Eateries on Campus query", request=Request(method="GET", url=BASE_URL + URL_PARAMS))]
 
-eatery_tests = TestGroup(name="Eatery", tests=tests, pod=Pod.EATERY)
+eatery_tests = TestGroup(name="Eatery", pod=Pod.EATERY, tests=tests)

--- a/src/eatery/tests.py
+++ b/src/eatery/tests.py
@@ -1,10 +1,11 @@
 from os import environ
+from urllib import parse
 
-from models import Pod, Request, Test, TestGroup
+from models import Application, Request, Test, TestGroup
 
 BASE_URL = environ["EATERY_BACKEND_URL"]
-URL_PARAMS = "?query=query%7Beateries%20%7Bname%7D%7D"
+URL_PARAMS = "?query=" + parse.quote("query { eateries { name } }")  # url encoding
 
 tests = [Test(name="Eateries on Campus query", request=Request(method="GET", url=BASE_URL + URL_PARAMS))]
 
-eatery_tests = TestGroup(name="Eatery", pod=Pod.EATERY, tests=tests)
+eatery_tests = TestGroup(application=Application.EATERY, name="Eatery", tests=tests)

--- a/src/eatery/tests.py
+++ b/src/eatery/tests.py
@@ -1,15 +1,13 @@
 from os import environ
 
-from models import Request, Test, TestGroup, Pod
+from models import Pod, Request, Test, TestGroup
 
 BASE_URL = environ["EATERY_BACKEND_URL"]
 
 tests = [
     Test(
         name="Eateries on Campus query",
-        request=Request(
-            method="GET", url=BASE_URL + "?query=query%7Beateries%20%7Bname%7D%7D"
-        ),
+        request=Request(method="GET", url=BASE_URL + "?query=query%7Beateries%20%7Bname%7D%7D"),
     )
 ]
 

--- a/src/eatery/tests.py
+++ b/src/eatery/tests.py
@@ -1,6 +1,6 @@
 from os import environ
 
-from models import Request, Test, TestGroup
+from models import Request, Test, TestGroup, Pod
 
 BASE_URL = environ["EATERY_BACKEND_URL"]
 
@@ -13,4 +13,4 @@ tests = [
     )
 ]
 
-eatery_tests = TestGroup(name="Eatery", tests=tests)
+eatery_tests = TestGroup(name="Eatery", tests=tests, pod=Pod.EATERY)

--- a/src/eatery/tests.py
+++ b/src/eatery/tests.py
@@ -3,12 +3,8 @@ from os import environ
 from models import Pod, Request, Test, TestGroup
 
 BASE_URL = environ["EATERY_BACKEND_URL"]
+URL_PARAMS = "?query=query%7Beateries%20%7Bname%7D%7D"
 
-tests = [
-    Test(
-        name="Eateries on Campus query",
-        request=Request(method="GET", url=BASE_URL + "?query=query%7Beateries%20%7Bname%7D%7D"),
-    )
-]
+tests = [Test(name="Eateries on Campus query", request=Request(method="GET", url=BASE_URL + URL_PARAMS))]
 
 eatery_tests = TestGroup(name="Eatery", tests=tests, pod=Pod.EATERY)

--- a/src/main.py
+++ b/src/main.py
@@ -2,19 +2,7 @@ from datetime import datetime
 from os import environ
 from subprocess import call
 import sys
-import config
 from models import Result, Pod
-
-# REMOVE THESE AND CHANGE ACTUAL ENVIROMENT VARIABLES BEFORE PULL REQUEST
-environ["SLACK_HOOK_URL"] = config.hook_url
-environ["MAIN_SLACK_USER_IDS"] = config.main_user_ids
-environ["EATERY_SLACK_USER_IDS"] = config.eater_user_ids
-environ["TRANSIT_SLACK_USER_IDS"] = config.transit_user_ids
-environ["UPLIFT_SLACK_USER_IDS"] = config.uplift_user_ids
-environ["EATERY_BACKEND_URL"] = config.eatery_backend_url
-environ["TRANSIT_BACKEND_URL"] = config.transit_backend_url
-environ["TRANSIT_DEV_BACKEND_URL"] = config.transit_dev_backend_url
-environ["UPLIFT_BACKEND_URL"] = config.uplift_backend_url
 
 # Add more test directories here...
 from coursegrab import coursegrab_tests

--- a/src/main.py
+++ b/src/main.py
@@ -49,7 +49,7 @@ if num_failures:
     passed_tests = num_tests - num_failures
     slack_message_text += "\t*Summary: `{}/{}` tests passed!* ".format(passed_tests, num_tests)
     # Tag appropriate users
-    user_ids = environ["MAIN_SLACK_USER_IDS"]
+    user_ids = environ["ADMIN_SLACK_USER_IDS"]
     if pod_error_tracking[Pod.EATERY]:
         user_ids += ", " + environ["EATERY_SLACK_USER_IDS"]
     if pod_error_tracking[Pod.TRANSIT]:

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from os import environ
 from subprocess import call
 import sys
-from models import Result, Pod
+from models import Pod, Result
 
 # Add more test directories here...
 from coursegrab import coursegrab_tests

--- a/src/main.py
+++ b/src/main.py
@@ -11,13 +11,7 @@ from transit import transit_dev_tests, transit_prod_tests
 from uplift import uplift_tests
 
 # And add the test group here as well!
-test_groups = [
-    coursegrab_tests,
-    eatery_tests,
-    transit_dev_tests,
-    transit_prod_tests,
-    uplift_tests,
-]
+test_groups = [coursegrab_tests, eatery_tests, transit_dev_tests, transit_prod_tests, uplift_tests]
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  APPLICATION CODE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -53,9 +47,7 @@ for test_group in test_groups:
 
 if num_failures:
     passed_tests = num_tests - num_failures
-    slack_message_text += "\t*Summary: `{}/{}` tests passed!* ".format(
-        passed_tests, num_tests
-    )
+    slack_message_text += "\t*Summary: `{}/{}` tests passed!* ".format(passed_tests, num_tests)
     # Tag appropriate users
     user_ids = environ["MAIN_SLACK_USER_IDS"]
     if pod_error_tracking[Pod.EATERY]:

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from os import environ
 from subprocess import call
 import sys
-from models import Pod, Result
+from models import Application, Result
 
 # Add more test directories here...
 from coursegrab import coursegrab_tests
@@ -20,7 +20,7 @@ FAILURE_STATUS = "FAILURE"
 
 num_tests = sum([len(test_group.tests) for test_group in test_groups])
 num_failures = 0
-pod_error_tracking = {Pod.EATERY: False, Pod.TRANSIT: False, Pod.UPLIFT: False}
+application_error_tracking = {Application.EATERY: False, Application.TRANSIT: False, Application.UPLIFT: False}
 
 slack_message_text = "*Starting new test run...*\n"
 
@@ -37,7 +37,7 @@ for test_group in test_groups:
         if test_result != Result.SUCCESS:
             test_group_failures += 1
             # Mark that there is an error in this pod
-            pod_error_tracking[test_group.pod] = True
+            application_error_tracking[test_group.application] = True
         test_group_text += "[{}] - {}\n".format(test.name, test_result.name)
 
     # Only print output if there was more than 0 failures in the group
@@ -50,11 +50,11 @@ if num_failures:
     slack_message_text += "\t*Summary: `{}/{}` tests passed!* ".format(passed_tests, num_tests)
     # Tag appropriate users
     user_ids = environ["ADMIN_SLACK_USER_IDS"]
-    if pod_error_tracking[Pod.EATERY]:
+    if application_error_tracking[Application.EATERY]:
         user_ids += ", " + environ["EATERY_SLACK_USER_IDS"]
-    if pod_error_tracking[Pod.TRANSIT]:
+    if application_error_tracking[Application.TRANSIT]:
         user_ids += ", " + environ["TRANSIT_SLACK_USER_IDS"]
-    if pod_error_tracking[Pod.UPLIFT]:
+    if application_error_tracking[Application.UPLIFT]:
         user_ids += ", " + environ["UPLIFT_SLACK_USER_IDS"]
     slack_message_text += "cc {}!".format(user_ids)
 else:

--- a/src/models.py
+++ b/src/models.py
@@ -8,8 +8,8 @@ class TestGroup:
     """
 
     def __init__(self, **kwargs):
+        self.application = kwargs["application"]
         self.name = kwargs["name"]
-        self.pod = kwargs["pod"]
         self.tests = kwargs["tests"]
 
 
@@ -43,9 +43,9 @@ class Result(Enum):
     TIMEOUT = auto()
 
 
-class Pod(Enum):
+class Application(Enum):
     """
-    Pod defines which pod a test group belongs to.
+    Application defines which application a test group belongs to.
     """
 
     EATERY = auto()

--- a/src/models.py
+++ b/src/models.py
@@ -10,6 +10,7 @@ class TestGroup:
     def __init__(self, **kwargs):
         self.name = kwargs["name"]
         self.tests = kwargs["tests"]
+        self.pod = kwargs["pod"]
 
 
 class Request:
@@ -40,6 +41,17 @@ class Result(Enum):
     SUCCESS = auto()
     ERROR = auto()
     TIMEOUT = auto()
+
+
+class Pod(Enum):
+    """
+    Pod defines which pod a test group belongs to
+    """
+
+    EATERY = auto()
+    TRANSIT = auto()
+    UPLIFT = auto()
+    COURSEGRAB = auto()
 
 
 class Test:

--- a/src/models.py
+++ b/src/models.py
@@ -9,13 +9,13 @@ class TestGroup:
 
     def __init__(self, **kwargs):
         self.name = kwargs["name"]
-        self.tests = kwargs["tests"]
         self.pod = kwargs["pod"]
+        self.tests = kwargs["tests"]
 
 
 class Request:
     """
-    Request defines a python [request] object
+    Request defines a python [request] object.
     """
 
     def __init__(self, **kwargs):
@@ -45,7 +45,7 @@ class Result(Enum):
 
 class Pod(Enum):
     """
-    Pod defines which pod a test group belongs to
+    Pod defines which pod a test group belongs to.
     """
 
     EATERY = auto()

--- a/src/transit/tests.py
+++ b/src/transit/tests.py
@@ -1,7 +1,7 @@
 import time
 from os import environ
 
-from models import Pod, Request, Test, TestGroup
+from models import Application, Request, Test, TestGroup
 
 BASE_DEV_URL = environ["TRANSIT_DEV_BACKEND_URL"]
 BASE_PROD_URL = environ["TRANSIT_BACKEND_URL"]
@@ -169,5 +169,7 @@ def generate_tests(base_url):
     ]
 
 
-transit_dev_tests = TestGroup(name="Transit Dev", pod=Pod.TRANSIT, tests=generate_tests(BASE_DEV_URL))
-transit_prod_tests = TestGroup(name="Transit Prod", pod=Pod.TRANSIT, tests=generate_tests(BASE_PROD_URL))
+transit_dev_tests = TestGroup(application=Application.TRANSIT, name="Transit Dev", tests=generate_tests(BASE_DEV_URL))
+transit_prod_tests = TestGroup(
+    application=Application.TRANSIT, name="Transit Prod", tests=generate_tests(BASE_PROD_URL)
+)

--- a/src/transit/tests.py
+++ b/src/transit/tests.py
@@ -169,5 +169,5 @@ def generate_tests(base_url):
     ]
 
 
-transit_dev_tests = TestGroup(name="Transit Dev", tests=generate_tests(BASE_DEV_URL), pod=Pod.TRANSIT)
-transit_prod_tests = TestGroup(name="Transit Prod", tests=generate_tests(BASE_PROD_URL), pod=Pod.TRANSIT)
+transit_dev_tests = TestGroup(name="Transit Dev", , pod=Pod.TRANSIT, tests=generate_tests(BASE_DEV_URL))
+transit_prod_tests = TestGroup(name="Transit Prod", , pod=Pod.TRANSIT, tests=generate_tests(BASE_PROD_URL))

--- a/src/transit/tests.py
+++ b/src/transit/tests.py
@@ -1,7 +1,7 @@
 import time
 from os import environ
 
-from models import Request, Test, TestGroup
+from models import Request, Test, TestGroup, Pod
 
 BASE_DEV_URL = environ["TRANSIT_DEV_BACKEND_URL"]
 BASE_PROD_URL = environ["TRANSIT_BACKEND_URL"]
@@ -79,7 +79,10 @@ def search_returns_suggestions(r):
     # Iterate over search suggestions
     for suggestion in response["data"]:
         # Check that we do not get the "Cannot filter property null" error
-        if "type" not in suggestion or suggestion["type"] not in ["googlePlace", "busStop"]:
+        if "type" not in suggestion or suggestion["type"] not in [
+            "googlePlace",
+            "busStop",
+        ]:
             return False
     return True
 
@@ -94,7 +97,10 @@ def generate_tests(base_url):
                 url=base_url[:-1].replace("https", "http") + ":5000",
             ),
         ),
-        Test(name="api/docs 200", request=Request(method="GET", url=base_url + "api/docs/")),
+        Test(
+            name="api/docs 200",
+            request=Request(method="GET", url=base_url + "api/docs/"),
+        ),
         Test(
             name="api/v1/allstops 200",
             request=Request(method="GET", url=base_url + "api/v1/allstops/"),
@@ -173,5 +179,9 @@ def generate_tests(base_url):
     ]
 
 
-transit_dev_tests = TestGroup(name="Transit Dev", tests=generate_tests(BASE_DEV_URL))
-transit_prod_tests = TestGroup(name="Transit Prod", tests=generate_tests(BASE_PROD_URL))
+transit_dev_tests = TestGroup(
+    name="Transit Dev", tests=generate_tests(BASE_DEV_URL), pod=Pod.TRANSIT
+)
+transit_prod_tests = TestGroup(
+    name="Transit Prod", tests=generate_tests(BASE_PROD_URL), pod=Pod.TRANSIT
+)

--- a/src/transit/tests.py
+++ b/src/transit/tests.py
@@ -6,6 +6,7 @@ from models import Pod, Request, Test, TestGroup
 BASE_DEV_URL = environ["TRANSIT_DEV_BACKEND_URL"]
 BASE_PROD_URL = environ["TRANSIT_BACKEND_URL"]
 
+
 # We want to verify that /allstops returns a list of type 'busStop' only
 def allstops_returns_bus_stops(r):
     response = r.json()

--- a/src/transit/tests.py
+++ b/src/transit/tests.py
@@ -169,5 +169,5 @@ def generate_tests(base_url):
     ]
 
 
-transit_dev_tests = TestGroup(name="Transit Dev", , pod=Pod.TRANSIT, tests=generate_tests(BASE_DEV_URL))
-transit_prod_tests = TestGroup(name="Transit Prod", , pod=Pod.TRANSIT, tests=generate_tests(BASE_PROD_URL))
+transit_dev_tests = TestGroup(name="Transit Dev", pod=Pod.TRANSIT, tests=generate_tests(BASE_DEV_URL))
+transit_prod_tests = TestGroup(name="Transit Prod", pod=Pod.TRANSIT, tests=generate_tests(BASE_PROD_URL))

--- a/src/transit/tests.py
+++ b/src/transit/tests.py
@@ -1,7 +1,7 @@
 import time
 from os import environ
 
-from models import Request, Test, TestGroup, Pod
+from models import Pod, Request, Test, TestGroup
 
 BASE_DEV_URL = environ["TRANSIT_DEV_BACKEND_URL"]
 BASE_PROD_URL = environ["TRANSIT_BACKEND_URL"]
@@ -79,10 +79,7 @@ def search_returns_suggestions(r):
     # Iterate over search suggestions
     for suggestion in response["data"]:
         # Check that we do not get the "Cannot filter property null" error
-        if "type" not in suggestion or suggestion["type"] not in [
-            "googlePlace",
-            "busStop",
-        ]:
+        if "type" not in suggestion or suggestion["type"] not in ["googlePlace", "busStop"]:
             return False
     return True
 
@@ -97,14 +94,8 @@ def generate_tests(base_url):
                 url=base_url[:-1].replace("https", "http") + ":5000",
             ),
         ),
-        Test(
-            name="api/docs 200",
-            request=Request(method="GET", url=base_url + "api/docs/"),
-        ),
-        Test(
-            name="api/v1/allstops 200",
-            request=Request(method="GET", url=base_url + "api/v1/allstops/"),
-        ),
+        Test(name="api/docs 200", request=Request(method="GET", url=base_url + "api/docs/")),
+        Test(name="api/v1/allstops 200", request=Request(method="GET", url=base_url + "api/v1/allstops/")),
         Test(
             name="api/v2/route 200",
             request=Request(
@@ -151,9 +142,7 @@ def generate_tests(base_url):
         ),
         Test(
             name="api/v1/search contains googlePlaces and busStops",
-            request=Request(
-                method="POST", url=base_url + "api/v2/search/", payload={"query": "st"}
-            ),
+            request=Request(method="POST", url=base_url + "api/v2/search/", payload={"query": "st"}),
             callback=search_returns_suggestions,
         ),
         Test(
@@ -179,9 +168,5 @@ def generate_tests(base_url):
     ]
 
 
-transit_dev_tests = TestGroup(
-    name="Transit Dev", tests=generate_tests(BASE_DEV_URL), pod=Pod.TRANSIT
-)
-transit_prod_tests = TestGroup(
-    name="Transit Prod", tests=generate_tests(BASE_PROD_URL), pod=Pod.TRANSIT
-)
+transit_dev_tests = TestGroup(name="Transit Dev", tests=generate_tests(BASE_DEV_URL), pod=Pod.TRANSIT)
+transit_prod_tests = TestGroup(name="Transit Prod", tests=generate_tests(BASE_PROD_URL), pod=Pod.TRANSIT)

--- a/src/uplift/tests.py
+++ b/src/uplift/tests.py
@@ -3,12 +3,8 @@ from os import environ
 from models import Pod, Request, Test, TestGroup
 
 BASE_URL = environ["UPLIFT_BACKEND_URL"]
+URL_PARAMS = "?query=query%7B%0Agyms%7B%0Aname%0A%7D%0A%7D"
 
-tests = [
-    Test(
-        name="Gyms on Campus query",
-        request=Request(method="GET", url=BASE_URL + "?query=query%7B%0Agyms%7B%0Aname%0A%7D%0A%7D"),
-    )
-]
+tests = [Test(name="Gyms on Campus query", request=Request(method="GET", url=BASE_URL + URL_PARAMS))]
 
 uplift_tests = TestGroup(name="Uplift", tests=tests, pod=Pod.UPLIFT)

--- a/src/uplift/tests.py
+++ b/src/uplift/tests.py
@@ -1,6 +1,6 @@
 from os import environ
 
-from models import Request, Test, TestGroup
+from models import Request, Test, TestGroup, Pod
 
 BASE_URL = environ["UPLIFT_BACKEND_URL"]
 
@@ -13,4 +13,4 @@ tests = [
     )
 ]
 
-uplift_tests = TestGroup(name="Uplift", tests=tests)
+uplift_tests = TestGroup(name="Uplift", tests=tests, pod=Pod.UPLIFT)

--- a/src/uplift/tests.py
+++ b/src/uplift/tests.py
@@ -1,10 +1,11 @@
 from os import environ
+from urllib import parse
 
-from models import Pod, Request, Test, TestGroup
+from models import Application, Request, Test, TestGroup
 
 BASE_URL = environ["UPLIFT_BACKEND_URL"]
-URL_PARAMS = "?query=query%7B%0Agyms%7B%0Aname%0A%7D%0A%7D"
+URL_PARAMS = "?query=" + parse.quote("query { gyms { name } }")  # url encoding
 
 tests = [Test(name="Gyms on Campus query", request=Request(method="GET", url=BASE_URL + URL_PARAMS))]
 
-uplift_tests = TestGroup(name="Uplift", pod=Pod.UPLIFT, tests=tests)
+uplift_tests = TestGroup(application=Application.UPLIFT, name="Uplift", tests=tests)

--- a/src/uplift/tests.py
+++ b/src/uplift/tests.py
@@ -7,4 +7,4 @@ URL_PARAMS = "?query=query%7B%0Agyms%7B%0Aname%0A%7D%0A%7D"
 
 tests = [Test(name="Gyms on Campus query", request=Request(method="GET", url=BASE_URL + URL_PARAMS))]
 
-uplift_tests = TestGroup(name="Uplift", tests=tests, pod=Pod.UPLIFT)
+uplift_tests = TestGroup(name="Uplift", pod=Pod.UPLIFT, tests=tests)

--- a/src/uplift/tests.py
+++ b/src/uplift/tests.py
@@ -1,15 +1,13 @@
 from os import environ
 
-from models import Request, Test, TestGroup, Pod
+from models import Pod, Request, Test, TestGroup
 
 BASE_URL = environ["UPLIFT_BACKEND_URL"]
 
 tests = [
     Test(
         name="Gyms on Campus query",
-        request=Request(
-            method="GET", url=BASE_URL + "?query=query%7B%0Agyms%7B%0Aname%0A%7D%0A%7D"
-        ),
+        request=Request(method="GET", url=BASE_URL + "?query=query%7B%0Agyms%7B%0Aname%0A%7D%0A%7D"),
     )
 ]
 


### PR DESCRIPTION
- **IMPORTANT:** Before approving this PR, the environment variables on the server must be changed.

- **Git Issue:** https://github.com/cuappdev/integration/issues/7

- **Context:** The Slack User ID's are provided via the environment variables on the server. Before my changes, if any test cases failed then Young, Megan, and Kevin were automatically cc'd on the outgoing Slack message.

- **Changes:**

1. In order to keep track of which test group belonged to which pod, I added a 'pod' field to the 'TestGroup' class. 

2. For readability/maintainability the values used for the 'pod' field are defined in the 'Pod' Enum.

3. Created a dictionary - 'pod_error_tracking' - in main.py that keeps track of which pod(s) failed test cases. Once all the tests have completed, the outgoing slack message is modified depending on the values stored in this dictionary.

4. Changed envrc.template to reflect changes in environment variables.



