### PR TITLE
Implement slack messaging to multiple channels.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,14 @@ jobs:
       run: python3.6 -m venv venv; source venv/bin/activate; pip install -r requirements.txt
     - name: Run main.py
       env:
-        SLACK_HOOK_URL: ${{ secrets.SLACK_HOOK_URL }}
-        SLACK_USER_IDS: ${{ secrets.SLACK_USER_IDS }}
+        SLACK_HOOK_COURSEGRAB_URL: ${{ secrets.SLACK_HOOK_COURSEGRAB_URL }}
+        SLACK_HOOK_EATERY_URL: ${{ secrets.SLACK_HOOK_EATERY_URL }}
+        SLACK_HOOK_TRANSIT_URL: ${{ secrets.SLACK_HOOK_TRANSIT_URL }}
+        SLACK_HOOK_UPLIFT_URL: ${{ secrets.SLACK_HOOK_UPLIFT_URL }}
+        ADMIN_SLACK_USER_IDS: ${{ secrets.ADMIN_SLACK_USER_IDS }}
+        EATERY_SLACK_USER_IDS: ${{ secrets.EATERY_SLACK_USER_IDS }}
+        TRANSIT_SLACK_USER_IDS: ${{ secrets.TRANSIT_SLACK_USER_IDS }}
+        UPLIFT_SLACK_USER_IDS: ${{ secrets.UPLIFT_SLACK_USER_IDS }}
         EATERY_BACKEND_URL: ${{ secrets.EATERY_BACKEND_URL }}
         TRANSIT_BACKEND_URL: ${{ secrets.TRANSIT_BACKEND_URL }}
         TRANSIT_DEV_BACKEND_URL: ${{ secrets.TRANSIT_DEV_BACKEND_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,14 @@ jobs:
       run: python3.6 -m venv venv; source venv/bin/activate; pip install -r requirements.txt
     - name: Run main.py
       env:
-        SLACK_HOOK_URL: ${{ secrets.SLACK_HOOK_URL }}
-        SLACK_USER_IDS: ${{ secrets.SLACK_USER_IDS }}
+        SLACK_HOOK_COURSEGRAB_URL: ${{ secrets.SLACK_HOOK_COURSEGRAB_URL }}
+        SLACK_HOOK_EATERY_URL: ${{ secrets.SLACK_HOOK_EATERY_URL }}
+        SLACK_HOOK_TRANSIT_URL: ${{ secrets.SLACK_HOOK_TRANSIT_URL }}
+        SLACK_HOOK_UPLIFT_URL: ${{ secrets.SLACK_HOOK_UPLIFT_URL }}
+        ADMIN_SLACK_USER_IDS: ${{ secrets.ADMIN_SLACK_USER_IDS }}
+        EATERY_SLACK_USER_IDS: ${{ secrets.EATERY_SLACK_USER_IDS }}
+        TRANSIT_SLACK_USER_IDS: ${{ secrets.TRANSIT_SLACK_USER_IDS }}
+        UPLIFT_SLACK_USER_IDS: ${{ secrets.UPLIFT_SLACK_USER_IDS }}
         EATERY_BACKEND_URL: ${{ secrets.EATERY_BACKEND_URL }}
         TRANSIT_BACKEND_URL: ${{ secrets.TRANSIT_BACKEND_URL }}
         TRANSIT_DEV_BACKEND_URL: ${{ secrets.TRANSIT_DEV_BACKEND_URL }}

--- a/envrc.template
+++ b/envrc.template
@@ -1,9 +1,14 @@
-export SLACK_HOOK_URL=""
 # It's important that the following env var is formatted exactly as follows!
 export ADMIN_SLACK_USER_IDS="<@U1>, <@U2>"
 export EATERY_SLACK_USER_IDS="<@U1>, <@U2>"
 export TRANSIT_SLACK_USER_IDS="<@U1>, <@U2>"
 export UPLIFT_SLACK_USER_IDS="<@U1>, <@U2>"
+
+# slack_hook_urls
+export SLACK_HOOK_COURSEGRAB_URL=""
+export SLACK_HOOK_EATERY_URL=""
+export SLACK_HOOK_TRANSIT_URL=""
+export SLACK_HOOK_UPLIFT_URL=""
 
 # backend_urls
 export EATERY_BACKEND_URL=""

--- a/src/main.py
+++ b/src/main.py
@@ -17,7 +17,7 @@ test_groups = [coursegrab_tests, eatery_tests, transit_dev_tests, transit_prod_t
 SUCCESS_STATUS = "SUCCESS"
 FAILURE_STATUS = "FAILURE"
 
-application_userID_mapping = {
+application_user_id_mapping = {
     Application.EATERY: environ["EATERY_SLACK_USER_IDS"],
     Application.TRANSIT: environ["TRANSIT_SLACK_USER_IDS"],
     Application.UPLIFT: environ["UPLIFT_SLACK_USER_IDS"],
@@ -48,8 +48,8 @@ for test_group in test_groups:
         slack_message_text += "\t*Summary: `{}/{}` tests passed!* ".format(passed_tests, num_test_group_tests)
         # Tag appropriate users
         user_ids = environ["ADMIN_SLACK_USER_IDS"]
-        if test_group.application in application_userID_mapping:
-            user_ids += ", " + application_userID_mapping[test_group.application]
+        if test_group.application in application_user_id_mapping:
+            user_ids += ", " + application_user_id_mapping[test_group.application]
         slack_message_text += "cc {}!".format(user_ids)
     else:
         slack_message_text = "*`{0}/{0}` tests passed :white_check_mark:*".format(num_test_group_tests)

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from os import environ
 from subprocess import call
 import sys
@@ -18,50 +17,46 @@ test_groups = [coursegrab_tests, eatery_tests, transit_dev_tests, transit_prod_t
 SUCCESS_STATUS = "SUCCESS"
 FAILURE_STATUS = "FAILURE"
 
-num_tests = sum([len(test_group.tests) for test_group in test_groups])
-num_failures = 0
-application_error_tracking = {Application.EATERY: False, Application.TRANSIT: False, Application.UPLIFT: False}
-
-slack_message_text = "*Starting new test run...*\n"
+application_userID_mapping = {
+    Application.EATERY: environ["EATERY_SLACK_USER_IDS"],
+    Application.TRANSIT: environ["TRANSIT_SLACK_USER_IDS"],
+    Application.UPLIFT: environ["UPLIFT_SLACK_USER_IDS"],
+}
+application_slackhook_mapping = {
+    Application.EATERY: environ["SLACK_HOOK_EATERY_URL"],
+    Application.TRANSIT: environ["SLACK_HOOK_TRANSIT_URL"],
+    Application.UPLIFT: environ["SLACK_HOOK_UPLIFT_URL"],
+    Application.COURSEGRAB: environ["SLACK_HOOK_COURSEGRAB_URL"],
+}
 
 for test_group in test_groups:
-    slack_message_text += "\tRunning tests for {}...\n".format(test_group.name)
-
-    test_group_text = ""
+    slack_message_text = "\tRunning tests for {}...\n".format(test_group.name)
     test_group_failures = 0
+    num_test_group_test = len(test_group.tests)
 
     for test in test_group.tests:
         test_status = SUCCESS_STATUS  # default to printing success
-
         test_result = test.get_result()
         if test_result != Result.SUCCESS:
             test_group_failures += 1
             # Mark that there is an error in this pod
-            application_error_tracking[test_group.application] = True
-        test_group_text += "[{}] - {}\n".format(test.name, test_result.name)
+            test_group.slack_message.should_send = True
+        slack_message_text += "[{}] - {}\n".format(test.name, test_result.name)
 
-    # Only print output if there was more than 0 failures in the group
-    if test_group_failures != 0:
-        num_failures += test_group_failures
-        slack_message_text += "> ```\n{}```\n".format(test_group_text)
+    if test_group_failures:
+        passed_tests = num_test_group_test - test_group_failures
+        slack_message_text += "\t*Summary: `{}/{}` tests passed!* ".format(passed_tests, num_test_group_test)
+        # Tag appropriate users
+        user_ids = environ["ADMIN_SLACK_USER_IDS"]
+        if test_group.application in application_userID_mapping:
+            user_ids += ", " + application_userID_mapping[test_group.application]
+        slack_message_text += "cc {}!".format(user_ids)
+    else:
+        slack_message_text = "*`{0}/{0}` tests passed :white_check_mark:*".format(num_test_group_test)
+    test_group.slack_message.text = slack_message_text
 
-if num_failures:
-    passed_tests = num_tests - num_failures
-    slack_message_text += "\t*Summary: `{}/{}` tests passed!* ".format(passed_tests, num_tests)
-    # Tag appropriate users
-    user_ids = environ["ADMIN_SLACK_USER_IDS"]
-    if application_error_tracking[Application.EATERY]:
-        user_ids += ", " + environ["EATERY_SLACK_USER_IDS"]
-    if application_error_tracking[Application.TRANSIT]:
-        user_ids += ", " + environ["TRANSIT_SLACK_USER_IDS"]
-    if application_error_tracking[Application.UPLIFT]:
-        user_ids += ", " + environ["UPLIFT_SLACK_USER_IDS"]
-    slack_message_text += "cc {}!".format(user_ids)
-else:
-    slack_message_text = "*`{0}/{0}` tests passed :white_check_mark:*".format(num_tests)
-
-# Always print output for debugging purposes
-print(slack_message_text)
+    # Always print output for debugging purposes
+    print(test_group.slack_message.text)
 
 # Send output to server if necessary
 if len(sys.argv) == 2:
@@ -70,8 +65,9 @@ if len(sys.argv) == 2:
     else:
         print("Unsupported operation, exiting...\n")
 
-if num_failures:
+CURL_PREFIX = """curl -X POST -H 'Content-type: application/json' --data """
+for test_group in test_groups:
     # Suppress output, this behavior can be changed in the future!
-    CURL_PREFIX = """curl -X POST -H 'Content-type: application/json' --data """
-    CURL_BODY = """'{{ "text": "{}" }}' """.format(slack_message_text)
-    call(CURL_PREFIX + CURL_BODY + environ["SLACK_HOOK_URL"], shell=True)
+    if test_group.slack_message.should_send:
+        CURL_BODY = """'{{ "text": "{}" }}' """.format(test_group.slack_message.text)
+        call(CURL_PREFIX + CURL_BODY + application_slackhook_mapping[test_group.application], shell=True)

--- a/src/main.py
+++ b/src/main.py
@@ -22,17 +22,17 @@ application_userID_mapping = {
     Application.TRANSIT: environ["TRANSIT_SLACK_USER_IDS"],
     Application.UPLIFT: environ["UPLIFT_SLACK_USER_IDS"],
 }
-application_slackhook_mapping = {
+application_slack_hook_mapping = {
+    Application.COURSEGRAB: environ["SLACK_HOOK_COURSEGRAB_URL"],
     Application.EATERY: environ["SLACK_HOOK_EATERY_URL"],
     Application.TRANSIT: environ["SLACK_HOOK_TRANSIT_URL"],
     Application.UPLIFT: environ["SLACK_HOOK_UPLIFT_URL"],
-    Application.COURSEGRAB: environ["SLACK_HOOK_COURSEGRAB_URL"],
 }
 
 for test_group in test_groups:
     slack_message_text = "\tRunning tests for {}...\n".format(test_group.name)
     test_group_failures = 0
-    num_test_group_test = len(test_group.tests)
+    num_test_group_tests = len(test_group.tests)
 
     for test in test_group.tests:
         test_status = SUCCESS_STATUS  # default to printing success
@@ -44,15 +44,15 @@ for test_group in test_groups:
         slack_message_text += "[{}] - {}\n".format(test.name, test_result.name)
 
     if test_group_failures:
-        passed_tests = num_test_group_test - test_group_failures
-        slack_message_text += "\t*Summary: `{}/{}` tests passed!* ".format(passed_tests, num_test_group_test)
+        passed_tests = num_test_group_tests - test_group_failures
+        slack_message_text += "\t*Summary: `{}/{}` tests passed!* ".format(passed_tests, num_test_group_tests)
         # Tag appropriate users
         user_ids = environ["ADMIN_SLACK_USER_IDS"]
         if test_group.application in application_userID_mapping:
             user_ids += ", " + application_userID_mapping[test_group.application]
         slack_message_text += "cc {}!".format(user_ids)
     else:
-        slack_message_text = "*`{0}/{0}` tests passed :white_check_mark:*".format(num_test_group_test)
+        slack_message_text = "*`{0}/{0}` tests passed :white_check_mark:*".format(num_test_group_tests)
     test_group.slack_message.text = slack_message_text
 
     # Always print output for debugging purposes
@@ -70,4 +70,4 @@ for test_group in test_groups:
     # Suppress output, this behavior can be changed in the future!
     if test_group.slack_message.should_send:
         CURL_BODY = """'{{ "text": "{}" }}' """.format(test_group.slack_message.text)
-        call(CURL_PREFIX + CURL_BODY + application_slackhook_mapping[test_group.application], shell=True)
+        call(CURL_PREFIX + CURL_BODY + application_slack_hook_mapping[test_group.application], shell=True)

--- a/src/models.py
+++ b/src/models.py
@@ -11,6 +11,7 @@ class TestGroup:
         self.application = kwargs["application"]
         self.name = kwargs["name"]
         self.tests = kwargs["tests"]
+        self.slack_message = SlackMessage(text="")
 
 
 class Request:
@@ -80,3 +81,14 @@ class Test:
             return Result.TIMEOUT
         except requests.exceptions.RequestException:
             return Result.ERROR
+
+
+class SlackMessage:
+    """
+    SlackMessage defines a slack message object which contains information on whether a
+    message should send and the contents of the message.
+    """
+
+    def __init__(self, **kwargs):
+        self.text = kwargs["text"]
+        self.should_send = False

--- a/src/models.py
+++ b/src/models.py
@@ -10,8 +10,8 @@ class TestGroup:
     def __init__(self, **kwargs):
         self.application = kwargs["application"]
         self.name = kwargs["name"]
-        self.tests = kwargs["tests"]
         self.slack_message = SlackMessage(text="")
+        self.tests = kwargs["tests"]
 
 
 class Request:


### PR DESCRIPTION
**- Git Issue:**: #8 

**- Context:** Before these changes, if a test case failed the integration slack app used a webhook to post all of the test results into the "#integration-results" channel.

**- Changes:** 
1. Slack:

-  Created new slack channels for each application being tested.

-  Created a new slack app 'Integration-v2' which can post in these new slack channels via webhooks.

2. Code: 

- Add SlackMessage class and add slack_message field to TestGroup class.

-  Add dicts to keep track of each application's webhook url and user ids.

-  Individualize the slack text for each testgroup.