### PR TITLE
Fix bug in transit test

### DIFF
--- a/src/transit/tests.py
+++ b/src/transit/tests.py
@@ -46,7 +46,7 @@ def route_number_non_null_callback(r):
     for route_directions in response["data"]["boardingSoon"]:
         for direction in route_directions["directions"]:
             # Walking directions can have a [None] routeNumber
-            if direction["type"] != "walk" and "routeNumber" is None:
+            if direction["type"] != "walk" and direction["routeNumber"] is None:
                 return False
 
     return True


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
Changed the 'route_number_non_null_callback' function to check if the dictionary value direction["routeNumber"] is None rather than the raw string "routeNumber".