### PR TITLE
Add two test cases for uplift

### DIFF
--- a/src/uplift/tests.py
+++ b/src/uplift/tests.py
@@ -29,13 +29,13 @@ URL_PARAMS_GYMS_NON_EMPTY = "?query=" + parse.quote(  # url encoding
 URL_PARAMS_CLASSES_NON_EMPTY = "?query=" + parse.quote(  # url encoding
     """
     query ClassesInfoQuery {
-          classes {
+        classes {
             date
             endTime
             isCancelled
             startTime
-          }
         }
+    }
         """
 )
 

--- a/src/uplift/tests.py
+++ b/src/uplift/tests.py
@@ -4,8 +4,64 @@ from urllib import parse
 from models import Application, Request, Test, TestGroup
 
 BASE_URL = environ["UPLIFT_BACKEND_URL"]
-URL_PARAMS = "?query=" + parse.quote("query { gyms { name } }")  # url encoding
+URL_PARAMS_BASIC = "?query=" + parse.quote("query { gyms { name } }")  # url encoding
+URL_PARAMS_GYMS_NON_EMPTY = "?query=" + parse.quote(  # url encoding
+    """
+    query GymsQuery {
+        gyms {
+            facilities {
+                equipment {
+                    name
+                }
+                name
+                times {
+                    day
+                    endTime
+                    startTime
+                    restrictions
+                }
+            }
+            name
+        }
+    }
+    """
+)
+URL_PARAMS_CLASSES_NON_EMPTY = "?query=" + parse.quote(  # url encoding
+    """
+    query ClassesInfoQuery {
+          classes {
+            date
+            endTime
+            isCancelled
+            startTime
+          }
+        }
+        """
+)
 
-tests = [Test(name="Gyms on Campus query", request=Request(method="GET", url=BASE_URL + URL_PARAMS))]
+
+def all_gym_fields_non_empty(r):
+    response = r.json()
+    return all(response["data"]["gyms"])
+
+
+def all_classes_fields_non_empty(r):
+    response = r.json()
+    return all(response["data"]["classes"])
+
+
+tests = [
+    Test(name="Gyms on Campus query", request=Request(method="GET", url=BASE_URL + URL_PARAMS_BASIC)),
+    Test(
+        name="Fields that should never be empty for gyms query",
+        request=Request(method="GET", url=BASE_URL + URL_PARAMS_GYMS_NON_EMPTY),
+        callback=all_gym_fields_non_empty,
+    ),
+    Test(
+        name="Fields that should never be empty for classes info query",
+        request=Request(method="GET", url=BASE_URL + URL_PARAMS_CLASSES_NON_EMPTY),
+        callback=all_classes_fields_non_empty,
+    ),
+]
 
 uplift_tests = TestGroup(application=Application.UPLIFT, name="Uplift", tests=tests)


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->

## Overview
Added two tests (a query for gyms and class info) to check that the fields which should always have a value indeed do.

## Changes Made
Added two functions and Test objects to uplift/tests.py that get data from the uplift backend and check to make sure all fields have a value.

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
To test my changes I ran the test suite locally, and looked at the debug output to check that the tests were running: "*`3/3` tests passed :white_check_mark:*".
The "3/3 tests passed" tells us that the two new tests are being run.

## Related PRs or Issues

<!-- List related PRs against other branches/repositories. -->
Related to "Add eatery tests to check certain fields always have a value(https://github.com/cuappdev/integration/pull/15)". Both PRs are part of the plan to make the test suite more robust.
