### PR TITLE
Add test to check GTFS feed expiration

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -34,6 +34,7 @@ for test_group in test_groups:
     test_group_failures = 0
     num_test_group_tests = len(test_group.tests)
 
+    diagnostic_text = ""
     for test in test_group.tests:
         test_status = SUCCESS_STATUS  # default to printing success
         test_result = test.get_result()
@@ -41,7 +42,8 @@ for test_group in test_groups:
             test_group_failures += 1
             # Mark that there is an error in this pod
             test_group.slack_message.should_send = True
-        slack_message_text += "[{}] - {}\n".format(test.name, test_result.name)
+        diagnostic_text += "[{}] - {}\n".format(test.name, test_result.name)
+    slack_message_text += "> ```\n{}```\n".format(diagnostic_text)
 
     if test_group_failures:
         passed_tests = num_test_group_tests - test_group_failures


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

Addressing first part of Alanna's issue to check GTFS expiration date and ping slack channel when data is about to expire.



## Changes Made

I use the new endpoint in `ithaca-transit-backend` to retrieve the GTFS feed info and compare the current date to the end date from the response.



## Test Coverage

Cannot currently test right now as I don't have the GTFS data locally to check. Have to coordinate with Alanna and verify.



## Next Steps

Verify that this properly pings the channel and fix the buffer for days accordingly. Also have to research/work on automatically fetching GTFS data (second part of issue) to build a new image and redeploy.



## Related PRs or Issues

https://github.com/cuappdev/integration/issues/14

