### PR TITLE
Remove /GTFSFeedInfo test from test group

### DIFF
--- a/src/transit/tests.py
+++ b/src/transit/tests.py
@@ -183,11 +183,6 @@ def generate_tests(base_url):
             ),
             callback=at_least_one_walking_route,
         ),
-        Test(
-            name="Checking GTFS feed expiration date",
-            request=Request(method="GET", url=base_url + "api/v1/GTFSFeedInfo/"),
-            callback=check_gtfs_feed_expiration,
-        ),
     ]
 
 


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview
Removed the `/GTFSFeedInfo` test from our test group as that endpoint is currently not available.



## Changes Made
Deleted the `/GTFSFeedInfo` test as that has currently been reverted.



## Test Coverage
Deleted a test, so nothing should change apart from the constant slack channel pinging.



## Next Steps 
Figure out what is causing the PR I had pushed earlier to `ithaca-transit-backend` to break, so that we can continue testing this endpoint that was reverted.

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->
