### PR TITLE
Fix search test to use v2/appleSearch and check for applePlace instead of googlePlace

### DIFF
--- a/src/transit/tests.py
+++ b/src/transit/tests.py
@@ -87,18 +87,24 @@ def no_walking_routes_in_boarding_soon(r):
 
 # We want to ensure that given a query string, /search does not result in an error,
 # namely "Cannot read property 'filter' of null," and instead returns a list of
-# valid suggestions - autocomplete results that are either of type 'busStop' or 'googlePlace'.
+# valid suggestions - autocomplete results that are either of type 'applePlace' or 'busStop'.
 def search_returns_suggestions(r):
     response = r.json()
     # Make sure response was successful
     if not response["success"]:
+        print("not successful")
         return False
 
-    # Iterate over search suggestions
+    # Iterate over two types of search suggestions
     for suggestion in response["data"]:
-        # Check that we do not get the "Cannot filter property null" error
-        if "type" not in suggestion or suggestion["type"] not in ["googlePlace", "busStop"]:
+        if suggestion not in ["applePlaces", "busStops"]:
             return False
+            for busStop in suggestion["busStops"]:
+                if not busStop.get("type") == "busStop":
+                    return False
+            for applePlace in suggestion["applePlaces"]:
+                if not applePlace.get("type") == "applePlace":
+                    return False
     return True
 
 
@@ -159,8 +165,8 @@ def generate_tests(base_url):
             callback=no_walking_routes_in_boarding_soon,
         ),
         Test(
-            name="api/v1/search contains googlePlaces and busStops",
-            request=Request(method="POST", url=base_url + "api/v2/search/", payload={"query": "st"}),
+            name="api/v2/appleSearch contains applePlaces and busStops",
+            request=Request(method="POST", url=base_url + "api/v2/appleSearch", payload={"query": "st"}),
             callback=search_returns_suggestions,
         ),
         Test(


### PR DESCRIPTION
## Overview
Our search test keeps failing because we still have it as the old v1/search's schema!

## Changes Made
Updated any reference of googlePlace to applePlace and the endpoint that we query for search results.

## Test Coverage
Tested it locally and all tests pass! Would like to see this deployed on the server though, so @seancorc can probably help with that?!

## Related PRs or Issues 
#24 
